### PR TITLE
Add support for transliteration from Latin to Cyrillic script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
     },
     "require": {
         "simplehtmldom/simplehtmldom": "2.0-RC2",
-        "sgi/transliterator": "^1.0"
+        "turanjanin/serbian-transliterator": "^1.0"
     }
 }

--- a/lib/Admin/Core.php
+++ b/lib/Admin/Core.php
@@ -9,7 +9,7 @@ use const SGI\STL\{
 
 use function SGI\STL\Utils\getOptions;
 
-use SGI\Transliterator;
+use Turanjanin\SerbianTransliterator\Transliterator;
 
 class Core
 {
@@ -124,7 +124,7 @@ class Core
         if (!$this->opts['file']['names'])
             return $filename;
 
-        $filename = Transliterator::cir_to_cut_lat($filename);
+        $filename = Transliterator::toAsciiLatin($filename);
 
         return $filename;
 
@@ -136,7 +136,7 @@ class Core
         if (!$this->opts['fixes']['permalinks'])
             return $title;
 
-        return Transliterator::cir_to_cut_lat(($title));
+        return Transliterator::toAsciiLatin(($title));
 
     }
 

--- a/lib/Admin/Settings/General.php
+++ b/lib/Admin/Settings/General.php
@@ -18,6 +18,15 @@ trait General
         );
 
         add_settings_field(
+            'stl_core_origin_script',
+            __('Original script', 'SrbTransLatin'),
+            [&$this, 'callback_option_origin_script'],
+            'stl_settings',
+            'stl_settings_core',
+            $this->opts['core']['origin_script']
+        );
+
+        add_settings_field(
             'stl_core_script',
             __('Default script', 'SrbTransLatin'),
             [&$this, 'callback_option_script'],
@@ -43,6 +52,26 @@ trait General
         printf(
             '<p>%s</p>',
             __('General settings control main functionality of the plugin', 'SrbTransLatin')
+        );
+
+    }
+
+    public function callback_option_origin_script($script)
+    {
+
+        $options = array(
+            'cir' => __('Cyrillic', 'SrbTransLatin'),
+            'lat' => __('Latin', 'SrbTransLatin')
+        );
+
+        Generator::select(
+            $options,
+            $script,
+            'sgi/stl/opt[core][origin_script]',
+            true,
+            '',
+            __('Main script used on the website', 'SrbTransLatin'),
+            ''
         );
 
     }

--- a/lib/Core/LanguageManager.php
+++ b/lib/Core/LanguageManager.php
@@ -68,6 +68,11 @@ class LanguageManager
 
     }
 
+    public function get_origin_script()
+    {
+        return $this->opts['core']['origin_script'];
+    }
+
     private function multilanguage_check()
     {
 

--- a/lib/Frontend/Core.php
+++ b/lib/Frontend/Core.php
@@ -7,8 +7,10 @@ use SGI\STL\Core\LanguageManager as LM,
     SGI\STL\Shortcode\Translator as Translator,
     simplehtmldom\HtmlDocument   as sHTMLd;
 
+use simplehtmldom\HtmlNode;
 use function SGI\STL\Utils\getOptions,
              SGI\STL\Utils\transliterate;
+use function SGI\STL\Utils\reverse_transliterate;
 
 class Core
 {
@@ -37,19 +39,22 @@ class Core
         $this->opts       = getOptions();
         $this->shortcodes = [];
 
+        if ( ! $this->lm->in_serbian ) :
+            return;
+        endif;
+
         /**
-         * Filters the priorty for transliteration engine
+         * Filters the priority for transliteration engine
          *
          * @since 2.0.0
          *
-         * @param filter_priority Integer defining transliterator priority
+         * @param $filter_priority Integer defining transliterator priority
          */
         $filter_priority = apply_filters('sgi/stl/filter_priority', 9999);
 
-        if ( $this->lm->get_script() == 'lat' && $this->lm->in_serbian ) :
+        if ( $this->lm->get_script() !== $this->opts['core']['origin_script'] ) :
             $this->loadTransliterator($filter_priority);
         endif;
-
     }
 
     /**
@@ -63,7 +68,7 @@ class Core
     public function loadTransliterator(int $filter_priority)
     {
 
-        add_action('wp_head', [&$this, 'buffer_start'], $filter_priority);
+        add_action('init', [&$this, 'buffer_start'], $filter_priority);
         add_action('wp_footer', [&$this, 'buffer_end'], $filter_priority);
 
         add_action('rss_head', [&$this, 'buffer_start'], $filter_priority);
@@ -77,11 +82,6 @@ class Core
 
         add_action('rss2_head', [&$this, 'buffer_start'], $filter_priority);
         add_action('rss2_footer', [&$this, 'buffer_end'], $filter_priority);
-
-        add_filter('gettext', [&$this, 'convert_script'], $filter_priority);
-        add_filter('ngettext', [&$this, 'convert_script'], $filter_priority);
-        add_filter('gettext_with_context', [&$this, 'convert_script'], $filter_priority);
-        add_filter('ngettext_with_context', [&$this, 'convert_script'], $filter_priority);
 
         // Change Script Specific images in content
         if ($this->opts['file']['translit'] && $this->opts['file']['content']) :
@@ -107,8 +107,6 @@ class Core
      */
     public function buffer_end()
     {
-
-        //ob_end_flush();
         $output = ob_get_clean();
 
         if ($this->opts['file']['translit'] && !$this->opts['file']['content']) :
@@ -120,13 +118,77 @@ class Core
         $this->shortcodes += Cyrilizer::get_shortcodes();
         $this->shortcodes += Translator::get_shortcodes();
 
-        echo strtr($output, $this->shortcodes);
+        $shortcodes = $this->shortcodes;
+
+        // Shortcode keys will be transliterated as well, we need to adjust them before replacement.
+        if ($this->lm->get_script() == 'cir') :
+            foreach ($this->shortcodes as $key => $value) :
+
+                $shortcodes[reverse_transliterate($key)] = $value;
+
+            endforeach;
+        endif;
+
+        echo strtr($output, $shortcodes);
 
     }
 
     public function convert_script($content)
     {
-        return transliterate($content);
+        if ($this->lm->get_script() === 'lat')
+            return transliterate($content);
+
+        $shtmld = new sHTMLd($content);
+        $node = $this->convert_html_to_cyrillic($shtmld->root);
+
+        return (string) $node;
+    }
+
+    /**
+     * Recursively iterates through the HTML nodes and transliterates the text.
+     *
+     * @param \simplehtmldom\HtmlNode $node
+     */
+    private function convert_html_to_cyrillic($node)
+    {
+        $skip_elements = [
+            'unknown',
+            'script',
+            'style',
+            'comment',
+            'cdata',
+            'svg',
+        ];
+
+        if (in_array($node->nodeName(), $skip_elements)) :
+            return $node;
+        endif;
+
+        $text_attributes = [
+            'alt',
+            'title',
+            'aria-label',
+            'placeholder',
+        ];
+
+        foreach ($text_attributes as $attribute) :
+            if ($node->hasAttribute($attribute))
+                $node->setAttribute($attribute, reverse_transliterate($node->getAttribute($attribute)));
+        endforeach;
+
+
+        if (isset($node->_[HtmlNode::HDOM_INFO_INNER]))
+            $node->_[HtmlNode::HDOM_INFO_INNER] = reverse_transliterate($node->_[HtmlNode::HDOM_INFO_INNER]);
+
+        if (isset($node->_[HtmlNode::HDOM_INFO_TEXT]))
+            $node->_[HtmlNode::HDOM_INFO_TEXT] = reverse_transliterate($node->_[HtmlNode::HDOM_INFO_TEXT]);
+
+        /** @var \simplehtmldom\HtmlNode $child_node */
+        foreach ($node->nodes as $child_node) :
+            $this->convert_html_to_cyrillic($child_node);
+        endforeach;
+
+        return $node;
     }
 
     public function change_image_urls($output)
@@ -136,9 +198,11 @@ class Core
         $delim  = $this->opts['file']['delim'];
 
         foreach ($shtmld->find('img') as $img) :
+            $origin_suffix = $this->opts['core']['origin_script'];
+            $replacement_suffix = $origin_suffix == 'cir' ? 'lat' : 'cir';
 
-            $img->src    = str_replace("{$delim}cir", "{$delim}lat", $img->src);
-            $img->srcset = str_replace("{$delim}cir", "{$delim}lat", $img->srcset);
+            $img->src    = str_replace("{$delim}{$origin_suffix}", "{$delim}{$replacement_suffix}", $img->src);
+            $img->srcset = str_replace("{$delim}{$origin_suffix}", "{$delim}{$replacement_suffix}", $img->srcset);
 
         endforeach;
 

--- a/lib/Shortcode/Cyrilizer.php
+++ b/lib/Shortcode/Cyrilizer.php
@@ -4,6 +4,7 @@ namespace SGI\STL\Shortcode;
 
 use function SGI\STL\Utils\{
     get_script,
+    get_origin_script,
     is_serbian
 };
 
@@ -23,9 +24,10 @@ class Cyrilizer
     public function shortcodeCallback($atts, $content)
     {
 
+        $origin_script = get_origin_script();
         $script = get_script();
 
-        if ($script == 'cir' || !is_serbian())
+        if ($origin_script == $script || !is_serbian())
             return $content;
 
         $uuid = uniqid();

--- a/lib/Shortcode/Translator.php
+++ b/lib/Shortcode/Translator.php
@@ -2,7 +2,10 @@
 
 namespace SGI\STL\Shortcode;
 
-use function SGI\STL\Utils\get_script;
+use function SGI\STL\Utils\{
+    get_script,
+    get_origin_script,
+};
 
 class Translator
 {
@@ -24,8 +27,9 @@ class Translator
         ], $atts);
 
         $script = get_script();
+        $origin_script = get_origin_script();
 
-        if ($script == 'cir')
+        if ($origin_script == $script)
             return $content;
 
         $uuid = uniqid();

--- a/lib/Utils/Global.php
+++ b/lib/Utils/Global.php
@@ -43,33 +43,34 @@ function getDefaultOptions() : array
 {
 
     return [
-        'migrated'       => false,
+        'migrated'          => false,
         'core'  => [
-            'script'     => 'cir',
-            'cookie'     => true,
-            'param'      => 'pismo',
+            'origin_script' => 'cir',
+            'script'        => 'cir',
+            'cookie'        => true,
+            'param'         => 'pismo',
         ],
         'file'  => [
-            'names'      => true,
-            'translit'   => true,
-            'content'    => true,
-            'delim'      => '-',
+            'names'         => true,
+            'translit'      => true,
+            'content'       => true,
+            'delim'         => '-',
         ],
         'fixes' =>[
-            'permalinks' => (get_option('WPLANG') == 'sr_RS') ? false : true, 
-            'search'     => true,
-            'ajax'       => false,
+            'permalinks'    => (get_option('WPLANG') == 'sr_RS') ? false : true,
+            'search'        => true,
+            'ajax'          => false,
         ],
         'menu'  => [
-            'extend'     => true,
-            'selector'   => '',
-            'type'       => 'dropdown',
-            'label'      => 'Писмо'
+            'extend'        => true,
+            'selector'      => '',
+            'type'          => 'dropdown',
+            'label'         => 'Писмо'
         ],
         'ml'    => [
-            'wpml'       => true,
-            'pll'        => true,
-            'qtx'        => true
+            'wpml'          => true,
+            'pll'           => true,
+            'qtx'           => true
         ]
     ];
 
@@ -96,6 +97,11 @@ function getOptions() : array
 function get_script()
 {
     return LM::get_instance()->get_script();
+}
+
+function get_origin_script()
+{
+    return LM::get_instance()->get_origin_script();
 }
 
 function get_script_param()

--- a/lib/Utils/Global.php
+++ b/lib/Utils/Global.php
@@ -2,8 +2,8 @@
 
 namespace SGI\STL\Utils;
 
-use SGI\STL\Core\LanguageManager   as LM,
-    SGI\Transliterator              as Transliterator;
+use SGI\STL\Core\LanguageManager                     as LM,
+    Turanjanin\SerbianTransliterator\Transliterator  as Transliterator;
 
 /**
  * Emulates wp_parse_args for multidimensional arrays
@@ -145,10 +145,8 @@ function transliterate(?string $content, bool $cut = false)
 {
 
     return (!$cut) ? 
-            Transliterator::cir_to_lat($content) :
-            Transliterator::cir_to_cut_lat($content);
-
-    return $content;
+            Transliterator::toLatin($content) :
+            Transliterator::toAsciiLatin($content);
 
 }
 
@@ -162,7 +160,7 @@ function transliterate(?string $content, bool $cut = false)
 function reverse_transliterate($content) : string
 {
 
-     return Transliterator::lat_to_cir($content);
+     return Transliterator::toCyrillic($content);
     
 }
 


### PR DESCRIPTION
This pull request adds support for creating Cyrillic version of a website which uses Latin as a main script. Even though this may not be original purpose of SrbTransLatin, I thought that it might be nice addition to already existing feature set. If you disagree, this might be a good starting point for new plugin - SrbTransCyrillic :)

In order to accomplish this, I've had to add new option on the settings page - "origin script". By default, it is set to "Cyrillic" and if you don't change that value, plugin will behave exactly the same as before.

However, if you choose to change this value to "Latin", the plugin will transliterate the whole page to Cyrillic if users select Cyrillic script. Since we are dealing with the raw HTML, I've used already included `simplehtmldom/simplehtmldom` library to extract and transliterate only the textual part of the page, leaving HTML tags, CSS and JS parts in their original form. This part still needs to be tested with various pages before we can be sure that it doesn't cause unexpected issues.

Finally, if you decide to merge this PR, we need to check transliteration of RSS and other feeds and, possibly, introduce additional shortcodes to achieve feature-parity with original extension.